### PR TITLE
Update sidebar for java to korean with translation is in progress status

### DIFF
--- a/_data/sidebars/general_sidebar.yml
+++ b/_data/sidebars/general_sidebar.yml
@@ -42,9 +42,9 @@ entries:
                   external_url: https://azure.github.io/azure-sdk-for-net/storage.html#azurestoragefilesshares
                 - title: Azure.Storage.Queues
                   external_url: https://azure.github.io/azure-sdk-for-net/storage.html#azurestoragequeues
-  - title: Java Guidelines
+  - title: Java 가이드라인 (번역중)
     folderitems:
-      - title: Design
+      - title: 디자인 (번역중)
         url: /java_introduction.html
       - title: Implementation
         url: /java_implementation.html


### PR DESCRIPTION
Before translating of java guideline's content, I updated sidebar for java to korean with translation is in progress status. 

![image](https://user-images.githubusercontent.com/28328195/131234452-e919c6d8-d6b2-4bb3-a0d0-ac6d6902e7cb.png)
