### PR TITLE
Fix: title in GitHub Repos which already has been translated

### DIFF
--- a/_data/sidebars/general_sidebar.yml
+++ b/_data/sidebars/general_sidebar.yml
@@ -130,11 +130,11 @@ entries:
         url: /ios_implementation.html
   - title: GitHub 저장소
     folderitems:
-      - title: Guidelines Contributions (영문)
+      - title: Guidelines Contributions
         url: /policies_adoption.html
-      - title: Repository structure (영문)
+      - title: Repository structure
         url: /policies_repostructure.html
-      - title: Repository branching (영문)
+      - title: Repository branching
         url: /policies_repobranching.html
       - title: 파이프라인
         url: /policies_pipelines.html

--- a/_data/sidebars/general_sidebar.yml
+++ b/_data/sidebars/general_sidebar.yml
@@ -130,11 +130,11 @@ entries:
         url: /ios_implementation.html
   - title: GitHub 저장소
     folderitems:
-      - title: Guidelines Contributions
+      - title: 가이드라인 기여
         url: /policies_adoption.html
-      - title: Repository structure
+      - title: 저장소 구조
         url: /policies_repostructure.html
-      - title: Repository branching
+      - title: 저장소 브랜치 관리
         url: /policies_repobranching.html
       - title: 파이프라인
         url: /policies_pipelines.html


### PR DESCRIPTION
### Request
There is a title that already has been translated in GitHub Repos but does not refelct (영문) delection in title.
Target: Guideline Contributions, Repository structure, Repository branching

### Related Issue
close #134 