### PR TITLE
closes #128; deleted an item from top-nav part on azure-sdk-korean blog

### DIFF
--- a/_data/topnav.yml
+++ b/_data/topnav.yml
@@ -3,8 +3,6 @@ topnav:
   items:
     - title: SDK 블로그 (영문)
       external_url: https://aka.ms/azsdk/blog
-    - title: Developer Korea 블로그
-      external_url: https://microsoft.github.io/developerkorea/
 
 
 topnav_dropdowns:


### PR DESCRIPTION
Related Issue :  #128 

I deleted "Developer Korea 블로그" item on top-nav part of azure-sdk-korean blog.

![스크린샷 2023-07-28 오전 1 27 02](https://github.com/Azure/azure-sdk-korean/assets/77106988/7d4406bf-7ed1-4bad-b5b9-c8ddeaf57b44)

<img width="1282" alt="스크린샷 2023-07-28 오전 1 15 23" src="https://github.com/Azure/azure-sdk-korean/assets/77106988/540bd505-ea09-4477-ad3e-54b634a45dea">


@microsoft-github-policy-service agree
