### PR TITLE
Sidebar position issue

### DIFF
--- a/js/customscripts.js
+++ b/js/customscripts.js
@@ -3,13 +3,8 @@ $('#mysidebar').height($(".nav").height());
 
 $( document ).ready(function() {
 
-    //this script says, if the height of the viewport is greater than 800px, then insert affix class, which makes the nav bar float in a fixed
-    // position as your scroll. if you have a lot of nav items, this height may not work for you.
-    var h = $(window).height();
-    //console.log (h);
-    if (h > 800) {
-        $( "#mysidebar" ).attr("class", "nav affix");
-    }
+    $( "#mysidebar" ).attr("class", "nav affix");
+
     // activate tooltips. although this is a bootstrap js function, it must be activated this way in your theme.
     $('[data-toggle="tooltip"]').tooltip({
         placement : 'top'


### PR DESCRIPTION
https://github.com/Azure/azure-sdk-korean/issues/129 To-Sidebar 개선 cause of the problem

If the height is less than 800px when accessing the site, 'affix class' (postion: fixed) is assigned to the sidebar.

https://github.com/Azure/azure-sdk-korean/blob/ed54ddbcb3fdf44f483ecce4960c12049c69b8f6/js/customscripts.js#L8-L12

If the width is less than 990px, the 'position: relative' property is assigned to the sidebar.

https://github.com/Azure/azure-sdk-korean/blob/ed54ddbcb3fdf44f483ecce4960c12049c69b8f6/css/customstyles.css#L1036-L1053

Lines 1036 to 1053 in [ed54ddb](https://github.com/Azure/azure-sdk-korean/commit/ed54ddbcb3fdf44f483ecce4960c12049c69b8f6)

If 'afiix Class' is not assigned (height > 800) and the width is over 990px, postion is not specified. See the screen below

![image](https://github.com/Azure/azure-sdk-korean/assets/46439363/fb59b6fe-78df-415d-843d-db75b99d86bc)


Therefore, it was modified so that the affix class is assigned in all conditions.

Compare
[Before](https://azure.github.io/azure-sdk-korean/)
[After](https://unki11.github.io/azure-sdk-korean/)


----


https://github.com/Azure/azure-sdk-korean/issues/129 To-Sidebar 개선 문제 원인

사이트 접속시 height가 800이하일 경우 sidebar에 'affix' class가(postion : fixed) 부여됨.

https://github.com/Azure/azure-sdk-korean/blob/ed54ddbcb3fdf44f483ecce4960c12049c69b8f6/js/customscripts.js#L8-L12

width가 990px 이하일 경우 sidebar에 position : relative 속성이 부여됨.

https://github.com/Azure/azure-sdk-korean/blob/ed54ddbcb3fdf44f483ecce4960c12049c69b8f6/css/customstyles.css#L1036-L1053

afiix Class가 부여되지 않고(height > 800) width가 990px 이상일 경우 postion이 따로 지정되지 않아 아래와 같이 보임.

![image](https://github.com/Azure/azure-sdk-korean/assets/46439363/fb59b6fe-78df-415d-843d-db75b99d86bc)


따라서 모든 조건에서 affix class이 할당되도록 수정하였습니다.

비교해보세요.
[변경전](https://azure.github.io/azure-sdk-korean/)
[변경후](https://unki11.github.io/azure-sdk-korean/)