### PR TITLE
Switch PAT to GitHubApps

### DIFF
--- a/eng/pipelines/template/steps/generate-releasenotes.yml
+++ b/eng/pipelines/template/steps/generate-releasenotes.yml
@@ -55,10 +55,12 @@ steps:
       -ForkRepoOwner "Azure" -RepoName "azure-sdk" -BranchPrefix '${{ parameters.PrBranchName }}' -AuthToken $(azuresdk-github-pat)
     displayName: Clean Up Stale Branches
 
+  - template: /eng/common/pipelines/templates/steps/login-to-github.yml
+
   - pwsh: |
       git clone https://github.com/Azure/azure-sdk.git $(AzureSDKReleaseNotesClonePath)
       cd $(AzureSDKReleaseNotesClonePath)
-      git remote add azure-sdk-fork "https://$(azuresdk-github-pat)@github.com/azure-sdk/azure-sdk.git"
+      git remote add azure-sdk-fork "https://$(GH_TOKEN)@github.com/azure/azure-sdk.git"
     displayName: Clone azure-sdk for release notes
     condition: and(succeeded(), ne(variables['AzureSDKReleaseNotesClonePath'], variables['AzureSDKClonePath']))
 
@@ -101,7 +103,7 @@ steps:
           -commonScriptPath $(AzureSDKToolsScriptsPath)
           -releaseDirectory $(AzureSDKReleaseNotesClonePath)/_data/releases
           -repoLanguage ${{ repo.value.Language }}
-          -github_pat '$(azuresdk-github-pat)'
+          -github_pat '$(GH_TOKEN)'
 
     - template: eng/common/pipelines/templates/steps/create-pull-request.yml@azure-sdk-tools
       parameters:

--- a/eng/pipelines/version-updater.yml
+++ b/eng/pipelines/version-updater.yml
@@ -24,13 +24,15 @@ steps:
     pwsh: true
     filePath: $(AzureSDKClonePath)/eng/scripts/Query-Azure-Packages.ps1
 
+- template: /eng/common/pipelines/templates/steps/login-to-github.yml
+
 - task: PowerShell@2
   displayName: Update packages from sdk release data
   inputs:
     pwsh: true
     filePath: $(AzureSDKClonePath)/eng/scripts/Update-Release-Versions.ps1
     arguments: >
-      -github_pat '$(azuresdk-github-pat)'
+      -github_pat '$(GH_TOKEN)'
 
 - task: PowerShell@2
   displayName: Update release DevOps work-items
@@ -38,12 +40,12 @@ steps:
     pwsh: true
     filePath: $(AzureSDKClonePath)/eng/scripts/Update-DevOps-WorkItems.ps1
     arguments: >
-      -github_pat '$(azuresdk-github-pat)'
+      -github_pat '$(GH_TOKEN)'
       -devops_pat '$(azuresdk-azure-sdk-devops-release-work-item-pat)'
 
 - pwsh: |
     # Some steps, like release notes, require this remote all the time so lets always setup even if there are no changes
-    git remote add azure-sdk-fork "https://$(azuresdk-github-pat)@github.com/azure-sdk/azure-sdk.git"
+    git remote add azure-sdk-fork "https://$(GH_TOKEN)@github.com/azure-sdk/azure-sdk.git"
   displayName: Setup azure-sdk-fork remote
   workingDirectory: $(AzureSDKClonePath)
 
@@ -68,7 +70,7 @@ steps:
 - template: template/steps/generate-releasenotes.yml
 
 - pwsh: |
-    git clone https://$(azuresdk-github-pat)@github.com/MicrosoftDocs/azure-dev-docs-pr $(System.DefaultWorkingDirectory)/azure-dev-docs-pr
+    git clone https://$(GH_TOKEN)@github.com/MicrosoftDocs/azure-dev-docs-pr $(System.DefaultWorkingDirectory)/azure-dev-docs-pr
   displayName: Clone azure-dev-docs-pr repo
 
 - task: PowerShell@2


### PR DESCRIPTION
This pull request updates the authentication method used for GitHub operations in pipeline scripts by replacing the `azuresdk-github-pat` variable with a new `GH_TOKEN` variable. It also adds a shared login step to standardize authentication. These changes help improve security and maintain consistency across the release notes and version updater pipelines.

Authentication updates:

* Replaced all instances of `$(azuresdk-github-pat)` with `$(GH_TOKEN)` for GitHub authentication in PowerShell scripts, arguments, and `git` remote URLs in both `generate-releasenotes.yml` and `version-updater.yml`. [[1]](diffhunk://#diff-3e533f9116866e1182ceb0dc188b9c08d4e4a92419cc17faa268839fca121785R58-R63) [[2]](diffhunk://#diff-3e533f9116866e1182ceb0dc188b9c08d4e4a92419cc17faa268839fca121785L104-R106) [[3]](diffhunk://#diff-0ee0d677b86f3952b7f56dabc3c38794abf144f15ed5d8ecbea0161d90f71df6R27-R48) [[4]](diffhunk://#diff-0ee0d677b86f3952b7f56dabc3c38794abf144f15ed5d8ecbea0161d90f71df6L71-R73)

Pipeline standardization:

* Added the `/eng/common/pipelines/templates/steps/login-to-github.yml` template to both `generate-releasenotes.yml` and `version-updater.yml` to centralize and standardize GitHub login steps. [[1]](diffhunk://#diff-3e533f9116866e1182ceb0dc188b9c08d4e4a92419cc17faa268839fca121785R58-R63) [[2]](diffhunk://#diff-0ee0d677b86f3952b7f56dabc3c38794abf144f15ed5d8ecbea0161d90f71df6R27-R48)